### PR TITLE
avoid importing <> from Data.Monoid

### DIFF
--- a/Physics/Sloth2D/Vector2D.hs
+++ b/Physics/Sloth2D/Vector2D.hs
@@ -11,7 +11,7 @@ module Physics.Sloth2D.Vector2D
     , withTranslation, withRotation, withScale
     ) where
 
-import Data.Monoid
+import Data.Monoid ( Monoid(mappend, mempty) )
 
 infixl 7 `dot`, `cross`
 infixl 5 `turn`, `turnL`, `turnNL`, `turnR`, `turnNR`, `parv`


### PR DESCRIPTION
When I tried compiling sloth2d, I got:

```
Physics/Sloth2D/Vector2D.hs:8:16:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Physics.Sloth2D.Vector2D.<>’,
                             defined at Physics/Sloth2D/Vector2D.hs:130:15
                          or ‘Data.Monoid.<>’,
                             imported from ‘Data.Monoid’ at Physics/Sloth2D/Vector2D.hs:14:1-18
```

This fixes that.
